### PR TITLE
Add MeetingRoom dataset metadata

### DIFF
--- a/datasets/MeetingRoom/metainfo.json
+++ b/datasets/MeetingRoom/metainfo.json
@@ -1,0 +1,37 @@
+{
+    "sequence1": {
+        "name": "sequence1",
+        "annot_fn_pattern": "cam{}_annot.txt",
+        "video_fn_pattern": "cam{}.mp4",
+        "cam_nbr": 4,
+        "video_frame_nbr": 1000,
+        "valid_frames_range": [0, 999],
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "homography": [
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ]
+        ],
+        "train_ratio": 0.8,
+        "eval_ratio": 0.2,
+        "test_ratio": 0.2
+    }
+}

--- a/datasets/MeetingRoom/sequence1/metainfo.json
+++ b/datasets/MeetingRoom/sequence1/metainfo.json
@@ -1,0 +1,37 @@
+{
+    "sequence1": {
+        "name": "sequence1",
+        "annot_fn_pattern": "cam{}_annot.txt",
+        "video_fn_pattern": "cam{}.mp4",
+        "cam_nbr": 4,
+        "video_frame_nbr": 1000,
+        "valid_frames_range": [0, 999],
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "homography": [
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ]
+        ],
+        "train_ratio": 0.8,
+        "eval_ratio": 0.2,
+        "test_ratio": 0.2
+    }
+}


### PR DESCRIPTION
## Summary
- add MeetingRoom dataset folder
- include `metainfo.json` with camera info and homography matrices

## Testing
- `python -m py_compile $(find . -name "*.py" | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_68495ba03dac832b9732336514ab4899