### PR TITLE
Add MeetingRoom dataset metainfo

### DIFF
--- a/datasets/MeetingRoom/Room1/.gitignore
+++ b/datasets/MeetingRoom/Room1/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/datasets/MeetingRoom/metainfo.json
+++ b/datasets/MeetingRoom/metainfo.json
@@ -1,0 +1,37 @@
+{
+    "Room1": {
+        "name": "Room1",
+        "annot_fn_pattern": "cam{}.txt",
+        "video_fn_pattern": "cam{}.mp4",
+        "cam_nbr": 4,
+        "video_frame_nbr": 0,
+        "valid_frames_range": [0, 0],
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "homography": [
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ],
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0]
+            ]
+        ],
+        "train_ratio": 0.9,
+        "eval_ratio": 0.2,
+        "test_ratio": 0.1
+    }
+}


### PR DESCRIPTION
## Summary
- add dataset folder `MeetingRoom` to match dataset layout
- include `metainfo.json` describing a 4-camera setup

## Testing
- `python -m json.tool datasets/MeetingRoom/metainfo.json`

------
https://chatgpt.com/codex/tasks/task_e_6849457d8180832ba285e05617281164